### PR TITLE
Remove illegal unicode character

### DIFF
--- a/exist-core/src/main/java/org/exist/util/io/MemoryContentsInputStream.java
+++ b/exist-core/src/main/java/org/exist/util/io/MemoryContentsInputStream.java
@@ -115,7 +115,7 @@ final class MemoryContentsInputStream extends InputStream {
     }
 
     // Java 9 method, has to compile under Java 1.7 so no @Override
-    public long transferTo​(OutputStream out) throws IOException {
+    public long transferTo(OutputStream out) throws IOException {
         long positionBefore = POSITION_UPDATER.get(this);
         long written = this.memoryContents.transferTo(out, positionBefore);
         POSITION_UPDATER.set(this, this.memoryContents.size());

--- a/exist-core/src/test/java/org/exist/util/io/MemoryContentsInputStreamTest.java
+++ b/exist-core/src/test/java/org/exist/util/io/MemoryContentsInputStreamTest.java
@@ -108,20 +108,20 @@ public class MemoryContentsInputStreamTest {
         verify(memoryContents);
     }
 
-//    @Test
-//    public void transferTo​() throws IOException {
-//        try (final FastByteArrayOutputStream out = new FastByteArrayOutputStream()) {
-//
-//            expect(memoryContents.size()).andReturn(123L);
-//            expect(memoryContents.transferTo(out, 0L)).andReturn(123L);
-//
-//            replay(memoryContents);
-//
-//            assertEquals(123L, inputStream.transferTo​(out));
-//
-//            verify(memoryContents);
-//        }
-//    }
+    @Test
+    public void transferTo​() throws IOException {
+        try (final FastByteArrayOutputStream out = new FastByteArrayOutputStream()) {
+
+            expect(memoryContents.size()).andReturn(123L);
+            expect(memoryContents.transferTo(out, 0L)).andReturn(123L);
+
+            replay(memoryContents);
+
+            assertEquals(123L, inputStream.transferTo(out));
+
+            verify(memoryContents);
+        }
+    }
 
     static byte[] write(int ch) {
         reportMatcher(new IArgumentMatcher() {


### PR DESCRIPTION
### Description:
Remove a non visible illegal character from the `transferTo` method signature