### PR TITLE
Docker MVP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: java
 
 dist: xenial
 
+services:
+  - docker
+
 matrix:
   include:
     - jdk: openjdk8
@@ -12,6 +15,22 @@ matrix:
     - os: osx
       osx_image: xcode9.3
       env: JAVA_HOME=$(/usr/libexec/java_home)
+
+
+# TODO: DP switch tag to 'release' when merging into develop, not before!
+deploy:
+  provider: script
+  skip_cleanup: true
+  on:
+    jdk: openjdk8
+    branch: master
+  #  before_script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  # see https://github.com/travis-ci/dpl/issues/673
+  script: >-
+    cd exist-docker &&
+    mvn -DskipTests -Ddocker.tag=experimental -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push &&
+    cd ..
+
 
 cache:
   directories:
@@ -26,6 +45,11 @@ before_install:
    - cd /tmp/maven-download-plugin
    - mvn clean install -DskipTests
    - cd $TRAVIS_BUILD_DIR
+
+# avoid 10k lines log limit
+install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Ddocker=true -B -V -q
+
+script: mvn -DskipTests -Ddocker=true -q clean package
 
 after_failure:
    - tar -cjf surefire-reports.tar.bz2 exist-core/target/surefire-reports

--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -13,7 +13,7 @@
     <packaging>pom</packaging>
 
     <name>eXist-db Docker Image</name>
-    <description>Docker Image of eXist-db NoSQL Database Client/Server</description>
+    <description>Minimal Docker Image of eXist-db NoSQL Database Client/Server with FO support</description>
 
     <scm>
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>

--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -161,9 +161,11 @@
                             <goal>build</goal>
                         </goals>
                         <configuration>
+                            <verbose>true</verbose>
                             <images>
                                 <image>
-                                    <name>existdb/existdb:%l</name>
+                                <!-- DP Todo switch back to %l when merging into develop  -->
+                                    <name>existdb/existdb:experimental</name>
                                     <build>
                                         <dockerFile>${project.build.outputDirectory}/Dockerfile</dockerFile>
                                         <contextDir>${assemble.dir}</contextDir>

--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -24,6 +24,8 @@
     <properties>
         <assemble.dir>${project.build.directory}/exist-docker-${project.version}-docker-dir</assemble.dir>
         <exist.uber.jar.filename>exist.uber.jar</exist.uber.jar.filename>
+        <!-- TODO: DP switch to 'latest' after merging into develop not before! -->
+        <docker.tag>mvn-latest</docker.tag>
     </properties>
 
     <dependencies>
@@ -155,12 +157,14 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.30.0</version>
                 <configuration>
-                    <verbose>true</verbose>
+                <!--  <verbose>true</verbose>  -->
                     <images>
                         <image>
-                            <!-- DP Todo switch back to %l when merging into develop  -->
-                            <name>existdb/existdb:experimental</name>
+                            <name>existdb/existdb:%v</name>
                             <build>
+                                <tags>
+                                    <tag>${docker.tag}</tag>
+                                </tags>
                                 <dockerFile>${project.build.outputDirectory}/Dockerfile</dockerFile>
                                 <contextDir>${assemble.dir}</contextDir>
                             </build>
@@ -176,7 +180,7 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>push latest</id>
+                        <id>push image to registry</id>
                         <phase>deploy</phase>
                         <goals>
                             <goal>push</goal>

--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -154,25 +154,33 @@
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.30.0</version>
+                <configuration>
+                    <verbose>true</verbose>
+                    <images>
+                        <image>
+                            <!-- DP Todo switch back to %l when merging into develop  -->
+                            <name>existdb/existdb:experimental</name>
+                            <build>
+                                <dockerFile>${project.build.outputDirectory}/Dockerfile</dockerFile>
+                                <contextDir>${assemble.dir}</contextDir>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
                 <executions>
                     <execution>
+                        <id>build image</id>
                         <phase>package</phase>
                         <goals>
                             <goal>build</goal>
                         </goals>
-                        <configuration>
-                            <verbose>true</verbose>
-                            <images>
-                                <image>
-                                <!-- DP Todo switch back to %l when merging into develop  -->
-                                    <name>existdb/existdb:experimental</name>
-                                    <build>
-                                        <dockerFile>${project.build.outputDirectory}/Dockerfile</dockerFile>
-                                        <contextDir>${assemble.dir}</contextDir>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>push latest</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>push</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libpng16-16 \
   ttf-dejavu-core
 
-FROM gcr.io/distroless/java
+FROM gcr.io/distroless/java:8
 
 # Copy over dependancies for Apache FOP, missing from gcr's JRE
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libfreetype.so.6.12.3 /usr/lib/x86_64-linux-gnu/libfreetype.so.6
@@ -50,6 +50,7 @@ ARG CACHE_MEM
 ARG MAX_BROKER
 
 ENV EXIST_HOME "/exist"
+ENV CLASSPATH=/exist/lib/${exist.uber.jar.filename}
 
 ENV JAVA_TOOL_OPTIONS \
   -Dfile.encoding=UTF8 \
@@ -66,13 +67,12 @@ ENV JAVA_TOOL_OPTIONS \
   -XX:+UseCGroupMemoryLimitForHeap \
   -XX:+UseG1GC \
   -XX:+UseStringDeduplication \
-  -XX:MaxRAMFraction=1
+  -XX:MaxRAMFraction=1 \
+  -XX:+ExitOnOutOfMemoryError
 
 HEALTHCHECK CMD [ "java", \
-    "-cp", "/exist/lib/${exist.uber.jar.filename}", \
     "org.exist.start.Main", "client", \
     "--no-gui",  "--xpath", "system:get-version()" ]
 
 ENTRYPOINT [ "java", \
-    "-cp", "/exist/lib/${exist.uber.jar.filename}", \
     "org.exist.start.Main", "jetty" ]

--- a/exist-docker/src/main/resources-filtered/README.md
+++ b/exist-docker/src/main/resources-filtered/README.md
@@ -1,0 +1,285 @@
+# ${project.description}
+${project.description}
+
+[![Build Status](https://travis-ci.com/eXist-db/exist.png?branch=develop)](https://travis-ci.com/eXist-db/exist)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/c5d7a02842dd4a3c85b1b2ad421b0d13)](https://www.codacy.com/app/eXist-db/exist?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=eXist-db/exist&amp;utm_campaign=Badge_Grade)
+[![License](https://img.shields.io/badge/license-AGPL%203.1-orange.svg)](https://www.gnu.org/licenses/agpl-3.0.html)
+[![](https://images.microbadger.com/badges/image/existdb/existdb.svg)](https://microbadger.com/images/existdb/existdb "Get your own image badge on microbadger.com")
+[![](https://images.microbadger.com/badges/version/existdb/existdb.svg)](https://microbadger.com/images/existdb/existdb "Get your own version badge on microbadger.com")
+[![](https://images.microbadger.com/badges/commit/existdb/existdb.svg)](https://microbadger.com/images/existdb/existdb "Get your own commit badge on microbadger.com")
+
+This module holds the source files for building a minimal docker image of the [exist-db](https://www.exist-db.org) xml 
+database, images are automatically updated as part of the build-test life-cycle. 
+The images are based on Google Cloud Platform's ["Distroless" Docker Images](https://github.com/GoogleCloudPlatform/distroless).
+
+
+## Requirements
+*   [Docker](https://www.docker.com): `18-stable`
+### For building
+*   [maven](https://maven.apache.org/): `^3.6.0`
+*   [java](https://www.java.com/): `8`
+
+## How to use
+Pre-build images are available on [DockerHub](https://hub.docker.com/r/existdb/existdb/). 
+There are two continuously updated channels:
+*   `release` for the latest stable releases based on the [`master` branch](https://github.com/eXist-db/exist/tree/master)
+*   `latest` for last commit to the [`develop` branch](https://github.com/eXist-db/exist/tree/develop).
+
+To download the image run:
+```bash
+docker pull existdb/existdb:latest
+```
+
+once the download is complete, you can run the image
+```bash
+docker run -it -d -p 8080:8080 -p 8443:8443 --name exist existdb/existdb:latest
+```
+
+### What does this do?
+
+*   `-it` allocates a TTY and keeps STDIN open.  This allows you to interact with the running Docker container via your console.
+*   `-d` detaches the container from the terminal that started it. So your container won't stop when you close the terminal.
+*   `-p` maps the Containers internal and external port assignments (we recommend sticking with matching pairs). This allows you to connect to the eXist-db Web Server running in the Docker container.
+*   `--name` lets you provide a name (instead of using a randomly generated one)
+
+The only required parts are `docker run existdb/existdb`. 
+For a full list of available options see the official [Docker documentation](https://docs.docker.com/engine/reference/commandline/run/)
+
+After running the `pull` and `run` commands, you can access eXist-db via [localhost:8080](localhost:8080) in your browser.
+
+To stop the container issue:
+```bash
+docker stop exist
+```
+
+or if you omitted the `-d` flag earlier press `CTRL-C` inside the terminal showing the exist logs.
+
+### Interacting with the running container
+You can interact with a running container as if it were a regular Linux host (without a shell in our case). 
+You can issue shell-like commands to the Java admin client, as we do throughout this readme, but you can't open the shell in interactive mode.
+
+The name of the container in this readme is `exist`, adjust the name in the commands to suit your needs:
+
+```bash
+# Using java syntax on a running eXist-db instances
+docker exec exist java org.exist.start.Main client --no-gui --xpath "system:get-version()"
+
+# Interacting with the JVM
+docker exec exist java -version
+```
+
+Containers build from this image run a periodical health-check to make sure that eXist-db is operating normally. 
+If `docker ps` reports `unhealthy` you can get a more detailed report with this command:  
+```bash
+docker inspect --format='{{json .State.Health}}' exist
+```
+
+### Logging
+There is a slight modification to eXist's logger to ease access to the logs via:
+```bash
+docker logs exist
+```
+This works best when providing the `-t` flag when running an image.
+
+## Use as base image
+A common usage of these images is as a base image for your own applications. 
+We'll take a quick look at three scenarios of increasing complexity, to demonstrate how to achieve common tasks from inside `Dockerfile`.
+
+### A simple app image
+The simplest and straightforward case assumes that you have a `.xar` app inside a `build` folder on the same level as the `Dockerfile`. 
+To get an image of an eXist-db instance with your app installed and running, simply adopt the `docker cp ...` command to the appropriate `Dockerfile` syntax.
+```
+FROM existdb/existdb:5.0.0
+
+COPY build/*.xar /exist/autodeploy
+
+```
+You should see something like this:
+
+```bash
+Sending build context to Docker daemon  4.337MB
+Step 1/2 : FROM existdb/existdb:5.0.0
+ ---> 3f4dbbce9afa
+Step 2/2 : COPY build/*.xar /exist/autodeploy
+ ---> ace38b0809de
+```
+
+The result is a new image of your app installed into eXist-db. 
+Since you didn't provide further instructions it will simply reuse the `EXPOSE`, `CMD`, `HEALTHCHECK`, etc instructions defined by the base image. 
+You can now publish this image to a docker registry and share it with others.
+
+### A slightly more complex single stage image
+The following example will install your app, but also modify the underlying eXist-db instance in which your app is running. 
+Instead of a local build directory, we'll download the `.xar` from the web, and copy a modified `conf.xml` from a `src/` directory along side your `Dockerfile`. 
+To execute any of the `docker exec …` style commands from this readme, we need to use `RUN`.
+
+```
+FROM existdb/existdb
+
+# NOTE: this is for syntax demo purposes only
+RUN [ "java", "org.exist.start.Main", "client", "--no-gui",  "-l", "-u", "admin", "-P", "", "-x", "sm:passwd('admin','123')" ]
+
+# use a modified conf.xml
+COPY src/conf.xml /exist/etc
+
+ADD https://github.com/eXist-db/documentation/releases/download/4.0.4/exist-documentation-4.0.4.xar /exist/autodeploy
+```
+
+The above is intended to demonstrate the kind of operations available to you in a single stage build. 
+For security reasons [more elaborate techniques](https://docs.docker.com/engine/swarm/secrets/) for not sharing your password in the clear are highly recommended, 
+such as the use of secure variables inside your CI environment. 
+However, the above shows you how to execute the [Java Admin Client](http://www.exist-db.org/exist/apps/doc/java-admin-client.xml) from inside a `Dockerfile`, 
+which in turn allows you to run any XQuery code you want when modifying the eXist-db instance that will ship with your images. You can also chain multiple `RUN` commands.
+
+As for the sequence of the commands, those with the most frequent changes should come last to avoid cache busting. 
+Chances are, you wouldn't change the admin password very often, but the `.xar` might change more frequently.
+
+### Multi-stage build with ant
+Lastly, you can eliminate external dependencies even further by using a multi-stage build. 
+To ensure compatibility between different Java engines we recommend sticking with debian based images for the builder stage.
+
+The following 2-stage build will download and install `ant` and `nodeJS` into a builder stage which then downloads frontend dependencies before building the `.xar` file.
+The second stage (each `FROM` begins a stage) is just the simple example from above. 
+Such a setup ensures that non of your collaborators has to have `java` or `nodeJS` installed, and is great for fully automated builds and deployment.
+
+```
+# START STAGE 1
+FROM openjdk:8-jdk-slim as builder
+
+USER root
+
+ENV ANT_VERSION 1.10.5
+ENV ANT_HOME /etc/ant-${ANT_VERSION}
+
+WORKDIR /tmp
+
+RUN wget http://www-us.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz \
+    && mkdir ant-${ANT_VERSION} \
+    && tar -zxvf apache-ant-${ANT_VERSION}-bin.tar.gz \
+    && mv apache-ant-${ANT_VERSION} ${ANT_HOME} \
+    && rm apache-ant-${ANT_VERSION}-bin.tar.gz \
+    && rm -rf ant-${ANT_VERSION} \
+    && rm -rf ${ANT_HOME}/manual \
+    && unset ANT_VERSION
+
+ENV PATH ${PATH}:${ANT_HOME}/bin
+
+WORKDIR /home/my-app
+COPY . .
+RUN apk add --no-cache --virtual .build-deps \
+ nodejs \
+ nodejs-npm \
+ git \
+ && npm i npm@latest -g \
+ && ant
+
+
+# START STAGE 2
+FROM existdb/existdb:release
+
+COPY --from=builder /home/my-app/build/*.xar /exist/autodeploy
+
+EXPOSE 8080 8443
+
+CMD [ "java", "org.exist.start.Main", "jetty" ]
+```
+
+The basic idea of the multi-staging is that everything you need for building your software should be managed by docker, 
+so that all collaborators can rely on one stable environment. In the end, and after how ever many stages you need, 
+only the files necessary to run your app should go into the final stage. The possibilities are virtually endless, 
+but with this example and the `Dockerfile` in this repo you should get a pretty good idea of how you might apply this idea to your own projects.
+
+## Development use via `docker-compose`
+We highly recommend use of a `docker-compose.yml` for use with [docker-compose](https://docs.docker.com/compose/). 
+docker-compose for local development or integration into multi-container environments. 
+For options on how to configure your own compose file, follow the link at the beginning of this paragraph.
+
+To start exist using a compose file, type:
+```bash
+# starting eXist-db
+docker-compose up -d
+# stop eXist-db
+docker-compose down
+```
+
+[Volumes](https://docs.docker.com/storage/volumes/) let you ensure data persistence between reboots, 
+in particular:
+
+*   `exist/data` so that any database changes persist through reboots and updates.
+*   `exist/etc` so you can configure eXist startup options.
+
+can be declared as mount volumes. 
+
+You can configure additional volumes e.g. for backups, 
+or additional services such as an nginx reverse proxy via a `docker-compose.yml`, to suite your needs.
+
+To update the exist-docker image from a newer version
+```bash
+docker-compose pull
+```
+
+### Caveat
+As with normal installations, the password for the default dba user `admin` is empty. 
+Change it via the [usermanager](http://localhost:8080/exist/apps/usermanager/index.html) or from CLI \(s.a.\).
+
+## Building the Image
+Building is integrated into maven via the [fabric8 plugin](https://dmp.fabric8.io): 
+To just build a docker image navigate inside the `exist-docker` folder and issue:
+```bash
+mvn -DskipTests clean package docker:build
+```
+
+### Available Arguments and Defaults
+eXist-db's cache size and maximum brokers can be configured at build time using the following syntax.
+```bash
+mvn -DskipTests clean package docker:build --build-arg MAX_CACHE=312 MAX_BROKER=15 .
+```
+
+NOTE: Due to the fact that the final images does not provide a shell, setting ENV variables via docker does not work.
+```bash
+# !This has no effect!
+docker run -dit -p8080:8080 -e MAX_BROKER=10 ae4d6d653d30
+```
+
+If you wish to permanently adopt a customized cache or broker configuration, 
+you can either make a local copy of the `Dockerfile` and edit the default values there.
+
+```bash
+ARG MAX_BROKER=10
+```
+
+Or modify eXist-db's configuration files via xslt scripts located at `exist-docker/src/main/xslt/`.
+For multi-stage builds e.g. [xmlstarlet](http://xmlstar.sourceforge.net) let's you modify the default config files from within the builder stage, 
+e.g.:
+```bash
+# Config files are modified here
+RUN echo 'modifying conf files'\
+&& cd $EXIST_HOME/etc \
+&& xmlstarlet ed  -L -s '/Configuration/Loggers/Root' -t elem -n 'AppenderRefTMP' -v '' \
+ -i //AppenderRefTMP -t attr -n 'ref' -v 'STDOUT'\
+ -r //AppenderRefTMP -v AppenderRef \
+ log4j2.xml
+```
+
+
+#### JVM configuration
+This image uses an advanced JVM configuration, via the  `JAVA_TOOL_OPTIONS` env variable inside the Dockerfile. 
+You should avoid the traditional way of setting the heap size via `-Xmx` arguments, 
+this can lead to frequent crashes since Java8 and Docker are (literally) not on the same page concerning available memory.
+
+Instead, use the `-XX:MaxRAMFraction=1` argument to modify the memory available to the JVM *inside* the container. 
+For production use we recommend to increase the value to `2` or even `4`. 
+This value expresses a ratio, so setting it to `2` means half the container's memory will be available to the JVM, '4' means ¼,  etc.
+
+To allocate e.g. 600mb to the container *around* the JVM use:
+```bash
+docker run -m 600m …
+```
+
+Lastly, this image uses a new garbage collection mechanism 
+[garbage first (G1)](https://docs.oracle.com/javase/9/gctuning/garbage-first-garbage-collector.htm#JSGCT-GUID-ED3AB6D3-FD9B-4447-9EDF-983ED2F7A573) `-XX:+UseG1GC` 
+and [string deduplication](http://openjdk.java.net/jeps/192) `-XX:+UseStringDeduplication` to improve performance.
+
+To disable or further tweak these features edit the relevant parts of the `Dockerfile`, or when running the image. 
+As always when using the latest and greatest, YMMV. 
+Feedback about real world experiences with this features in connection with eXist-db is very much welcome.


### PR DESCRIPTION
### Included and tested
Unlike other exist releases, docker already has two continuous deployment channels `release` and `latest`. This PR concludes the updated docker mvp. Deployments to the `:release` channel will happen via travis from the `master` branch. Images are working and persisting app data. Commands to both exist and java from `docker exec` return the expected results.

### Caveat
It also includes a number of TODOs which need to be fixed immediately *after* merging `maven-build` into `develop`. When that merge comes we need (in that order):

1.   Disable the build hooks going from `eXist-db/exist` to hub.docker
1.1  disable the `autobuild` configuration for `develop` on [dockerhub](https://cloud.docker.com/u/existdb/repository/docker/existdb/existdb)
2. merge the `maven-build` into `develop`
3. push a new commit that addresses the `TODOs` into develop

If we wish to merge `maven-build` into `develop` and then immediately create a `RC8` release, additional steps are necessary in the eXist-db/docker-existdb repo. The details depend on if we also want to simultaneously release `4.7.0` as in the past.

Travis is skipping all tests, obviously this needs adjustment before merging into develop. To push images Travis needs credenials, these will never work from PRs. Latest run with successful push is [here](https://travis-ci.com/duncdrum/exist/jobs/199401611)

### not included
-   docker-compose, this can be integrated into the plugin. I have adjusted the readme, but we could to more 
-   tests (we should port our shell based tests and integrated them into maven)
-   running `mvn deploy` or `maven release` without admin access to hub.docker is untested
-   we need to adjust the cron job creating nightly builds to now also create `:latest` images
